### PR TITLE
expose rbush tree, allowing extra flexibility if needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,13 +22,15 @@ function whichPolygon(data) {
 
     var tree = rbush().load(bboxes);
 
-    return function query(p) {
+    var query = function (p) {
         var result = tree.search([p[0], p[1], p[0], p[1]]);
         for (var i = 0; i < result.length; i++) {
             if (insidePolygon(result[i][4], p)) return result[i][5];
         }
         return null;
     };
+    query.tree = tree;
+    return query;
 }
 
 // ray casting algorithm for detecting if point is in polygon

--- a/test/test.js
+++ b/test/test.js
@@ -13,3 +13,9 @@ test('queries polygons', function (t) {
 	t.equal(query([-50, 30]), null);
 	t.end();
 });
+
+test('returns tree', function (t) {
+  t.ok(query.tree);
+  t.type(query.tree, 'object');
+  t.end();
+});


### PR DESCRIPTION
When using `which-polygon` to determine what country a tile belongs to, I found some edge cases where I need access to the rbush tree to handle cases where a single point test is insufficient. Rather than build a second copy of the rbush tree, it seems easier and more logical to just expose the tree used internally in `which-polygon`.
