### PR TITLE
added bbox test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: node_js
-node_js:
-  - 0.12
+node_js: node

--- a/index.js
+++ b/index.js
@@ -45,13 +45,8 @@ function whichPolygon(data) {
             maxX: bbox[2],
             maxY: bbox[3]
         });
-        var bboxCenter = [
-            (bbox[0] + bbox[2]) / 2,
-            (bbox[1] + bbox[3]) / 2
-        ];
         for (var i = 0; i < result.length; i++) {
-            var coords = result[i].coords;
-            if (insidePolygon(coords, bboxCenter) || lineclip(coords[0], bbox).length > 0) {
+            if (polygonIntersectsBBox(result[i].coords, bbox)) {
                 output.push(result[i].props);
             }
         }
@@ -59,6 +54,18 @@ function whichPolygon(data) {
     };
 
     return query;
+}
+
+function polygonIntersectsBBox(polygon, bbox) {
+    var bboxCenter = [
+        (bbox[0] + bbox[2]) / 2,
+        (bbox[1] + bbox[3]) / 2
+    ];
+    if (insidePolygon(polygon, bboxCenter)) return true;
+    for (var i = 0; i < polygon.length; i++) {
+        if (lineclip(polygon[i], bbox).length > 0) return true;
+    }
+    return false;
 }
 
 // ray casting algorithm for detecting if point is in polygon

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Index for matching points against a set of GeoJSON polygons",
   "main": "index.js",
   "dependencies": {
-    "rbush": "^2.0.1"
+    "rbush": "^2.0.1",
+    "lineclip": "^1.1.5"
   },
   "devDependencies": {
     "eslint": "^3.6.0",

--- a/test/test.js
+++ b/test/test.js
@@ -7,9 +7,20 @@ var data = require('./fixtures/states.json');
 
 var query = whichPolygon(data);
 
-test('queries polygons', function (t) {
+test('queries polygons with a point', function (t) {
 	t.equal(query([-100, 45]).name, "South Dakota");
 	t.equal(query([-90, 30]).name, "Louisiana");
 	t.equal(query([-50, 30]), null);
 	t.end();
+});
+
+
+test('queries polygons with a bbox', function (t) {
+  t.equal(query.bbox([-100, 45, -99.5, 45.5])[0].name, "South Dakota");
+
+  var qq = query.bbox([-104.2, 44, -103, 45]);
+  var names = qq.map(function (el) { return el.name; }).sort();
+  t.equal(qq.length, 2);
+  t.like(names, ["South Dakota", "Wyoming"]);
+  t.end();
 });


### PR DESCRIPTION
querying with a bbox returns properties for all polygons that it touches. 

If there's only one hit, just the match is returned instead of an array.

still exposed the rbush tree, in case anybody using `which-polygon` requires additional access.
