### PR TITLE
Support for search of overlapping polygons

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ query([30.5, 50.5]).admin; // 'Ukraine'
 The input GeoJSON must be a feature collection of polygons or multipolygons.
 The query returns the properties of the matched polygon feature.
 
+By default query returns first polygon that has been found (object or null).
+To return array of all found polygons use option `multi` as second parameter
+
+```js
+query([14.3,51.2],true); // [ { props1 }, { props2 }, { props3  } ... ] || null
+```
+
 Once the index is built, queries are pretty fast —
 17 seconds to query 1 million random locations on a Macbook Pro in this particular case.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ query([30.5, 50.5]).admin; // 'Ukraine'
 The input GeoJSON must be a feature collection of polygons or multipolygons.
 The query returns the properties of the matched polygon feature.
 
-By default query returns first polygon that has been found (object or null).
-To return array of all found polygons use option `multi` as second parameter
+By default query returns properties of the first polygon that has been found (object or null).
+To return array of all found polygon propertires use option `multi` as a second parameter
 
 ```js
 query([14.3,51.2],true); // [ { props1 }, { props2 }, { props3  } ... ] || null

--- a/index.js
+++ b/index.js
@@ -23,17 +23,23 @@ function whichPolygon(data) {
 
     var tree = rbush().load(bboxes);
 
-    function query(p) {
-        var result = tree.search({
+    function query( p, multi ) {
+        var output = []
+        , result = tree.search({
             minX: p[0],
             minY: p[1],
             maxX: p[0],
             maxY: p[1]
-        });
+        });        
         for (var i = 0; i < result.length; i++) {
-            if (insidePolygon(result[i].coords, p)) return result[i].props;
+            if ( insidePolygon(result[i].coords, p) ) {
+                
+                if( multi ) output.push( result[i].props )
+                else return result[i].props
+                
+            }   
         }
-        return null;
+        return multi && output.length ? output : null;
     }
 
     query.tree = tree;


### PR DESCRIPTION
Simple optional parameter `multi` makes API backward compatible and does not have any performance penalty.