### PR TITLE
Include GeoJSON `id` in tree item, return whole item 

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,9 @@ function whichPolygon(data) {
         for (var i = 0; i < result.length; i++) {
             if (insidePolygon(result[i].coords, p)) {
                 if (multi)
-                    output.push(result[i].props);
+                    output.push(result[i]);
                 else
-                    return result[i].props;
+                    return result[i];
             }
         }
         return multi && output.length ? output : null;
@@ -53,7 +53,7 @@ function whichPolygon(data) {
         });
         for (var i = 0; i < result.length; i++) {
             if (polygonIntersectsBBox(result[i].coords, bbox)) {
-                output.push(result[i].props);
+                output.push(result[i]);
             }
         }
         return output;
@@ -97,7 +97,7 @@ function treeItem(coords, props, id) {
         maxX: -Infinity,
         maxY: -Infinity,
         coords: coords,
-        props: props
+        properties: props
     };
 
     if (id !== undefined) {

--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ function whichPolygon(data) {
         var coords = feature.geometry.coordinates;
 
         if (feature.geometry.type === 'Polygon') {
-            bboxes.push(treeItem(coords, feature.properties));
+            bboxes.push(treeItem(coords, feature.properties, feature.id));
 
         } else if (feature.geometry.type === 'MultiPolygon') {
             for (var j = 0; j < coords.length; j++) {
-                bboxes.push(treeItem(coords[j], feature.properties));
+                bboxes.push(treeItem(coords[j], feature.properties, feature.id));
             }
         }
     }
@@ -90,7 +90,7 @@ function rayIntersect(p, p1, p2) {
     return ((p1[1] > p[1]) !== (p2[1] > p[1])) && (p[0] < (p2[0] - p1[0]) * (p[1] - p1[1]) / (p2[1] - p1[1]) + p1[0]);
 }
 
-function treeItem(coords, props) {
+function treeItem(coords, props, id) {
     var item = {
         minX: Infinity,
         minY: Infinity,
@@ -99,6 +99,10 @@ function treeItem(coords, props) {
         coords: coords,
         props: props
     };
+
+    if (id !== undefined) {
+        item.id = id;
+    }
 
     for (var i = 0; i < coords[0].length; i++) {
         var p = coords[0][i];

--- a/test/fixtures/colorado.json
+++ b/test/fixtures/colorado.json
@@ -1,0 +1,22 @@
+{
+  "type":"FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "colorado",
+      "properties": {},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-109.05, 37],
+            [-102.05, 37],
+            [-102.05, 41],
+            [-109.05, 41],
+            [-109.05, 37]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -34,3 +34,11 @@ test('queries overlapping polygons with a point', function (t) {
     t.equal(queryOverlapping([-10, -10]), null);
     t.end();
 });
+
+test('queries features with id', function (t) {
+    var colorado = require('./fixtures/colorado.json');
+    var query = whichPolygon(colorado);
+
+    t.equal(query([-105, 39]).id, "colorado", "query feature with id");
+    t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -8,17 +8,17 @@ var data = require('./fixtures/states.json');
 var query = whichPolygon(data);
 
 test('queries polygons with a point', function (t) {
-    t.equal(query([-100, 45]).name, "South Dakota");
-    t.equal(query([-90, 30]).name, "Louisiana");
+    t.equal(query([-100, 45]).properties.name, "South Dakota");
+    t.equal(query([-90, 30]).properties.name, "Louisiana");
     t.equal(query([-50, 30]), null);
     t.end();
 });
 
 test('queries polygons with a bbox', function (t) {
-    t.equal(query.bbox([-100, 45, -99.5, 45.5])[0].name, "South Dakota");
+    t.equal(query.bbox([-100, 45, -99.5, 45.5])[0].properties.name, "South Dakota");
 
     var qq = query.bbox([-104.2, 44, -103, 45]);
-    var names = qq.map(function (el) { return el.name; }).sort();
+    var names = qq.map(function (el) { return el.properties.name; }).sort();
     t.equal(qq.length, 2);
     t.like(names, ["South Dakota", "Wyoming"]);
     t.end();
@@ -27,8 +27,10 @@ test('queries polygons with a bbox', function (t) {
 test('queries overlapping polygons with a point', function (t) {
     var dataOverlapping = require('./fixtures/overlapping.json');
     var queryOverlapping = whichPolygon(dataOverlapping);
-    t.equal(queryOverlapping([7.5, 7.5]).name, "A", "without multi option");
-    t.same(queryOverlapping([7.5, 7.5], true), [{"name": "A"}, {"name": "B"}], "with multi option");
+
+    t.equal(queryOverlapping([7.5, 7.5]).properties.name, "A", "without multi option");
+    var result = queryOverlapping([7.5, 7.5], true);
+    t.same([result[0].properties, result[1].properties], [{"name": "A"}, {"name": "B"}], "with multi option");
     t.equal(queryOverlapping([-10, -10]), null);
     t.end();
 });


### PR DESCRIPTION
I have a bunch of GeoJSON Featues without `properties`, but they each have an `id` ([see RFC7946](https://tools.ietf.org/html/rfc7946#section-3.2))

Can we change this library to:
* include the `id` in the cached tree items (if not `undefined`)
* return the whole tree item in the results, not just the `props`

This is an API breaking change, but it would be great to support `id` lookup.
