### PR TITLE
Account for possible null GeoJSON geometry

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ function whichPolygon(data) {
     var bboxes = [];
     for (var i = 0; i < data.features.length; i++) {
         var feature = data.features[i];
+
+        // unlocated GeoJSON features can have null `geometry`
+        if (!feature.geometry) continue;
+
         var coords = feature.geometry.coordinates;
 
         if (feature.geometry.type === 'Polygon') {


### PR DESCRIPTION
Thanks for the great package! Just a small compatibility fix here. "Unlocated" GeoJSON features [can have their `geometry` set as `null`](https://tools.ietf.org/html/rfc7946#section-3.2). This PR adds support for this case.